### PR TITLE
Set opt-level 3 for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ members = [
     "launchers/native",
 ]
 
+# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
+[profile.dev.package.my-game]
+opt-level = 0
+[profile.dev.package."*"]
+opt-level = 3
+
 [[bin]]
 name="native-launcher"
 path="launchers/native/src/main.rs"


### PR DESCRIPTION
Bevy, and some other crates like rapier, are much slower when compiled in debug than in release. By setting

```
[profile.dev.package."*"]
opt-level = 3
```

in cargo.toml, we compile dependencies with optimizations on but our actual code is compiled without it. With incremental builds, there's no difference in compile times after the first build.

This makes CI take a very long time since caching is broken, so be sure to also merge #24 to fix that.